### PR TITLE
Add tgden — Telegram search engine with free API and MCP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 * [Telegram Chinese Search](http://www.sssoou.com/)
 * [名刀电报搜索](https://xtea.io/ts.html#gsc.tab=0)
 * [Telegra.ph Search Engine](https://telegcrack.com/)
-* [tgden](https://tgden.com/en/search) - Full-text search across 1.29M channels, 283k group chats and 158k bots, including search over what those channels actually posted. Free REST API and a hosted MCP endpoint for AI agents, no account or key.
+* [tgden](https://tgden.com/en/search) - Full-text search across 1.2M+ channels, 245k+ group chats and 160k+ bots, including search over what those channels actually posted. Free REST API (no key, CORS-enabled) and a hosted MCP endpoint for AI agents, no account needed.
 
 ## [↑](#contents) Directories And Catalogues
 * [TelegramDB](https://telegramdb.org/)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 * [Telegram Chinese Search](http://www.sssoou.com/)
 * [名刀电报搜索](https://xtea.io/ts.html#gsc.tab=0)
 * [Telegra.ph Search Engine](https://telegcrack.com/)
+* [tgden](https://tgden.com/en/search) - Full-text search across 1.29M channels, 283k group chats and 158k bots, including search over what those channels actually posted. Free REST API and a hosted MCP endpoint for AI agents, no account or key.
 
 ## [↑](#contents) Directories And Catalogues
 * [TelegramDB](https://telegramdb.org/)


### PR DESCRIPTION
Adding [tgden](https://tgden.com) to **Search Engines**.

It fits this list because it indexes public Telegram entities and their content, and exposes that index in machine-readable form — useful for research and OSINT work without needing a Telegram account.

**Live counts** (read from the catalog today, not marketing numbers):
- 1,298,868 channels
- 282,719 group chats
- 157,909 bots

**Why it is different from the catalogues already listed** (TGStat, Telemetr, TgramSearch): those are web UIs. tgden additionally exposes

- a free REST API with no key — `curl 'https://tgden.com/api/catalog?limit=2'`
- a hosted **MCP endpoint** for AI agents — `https://tgden.com/api/mcp` (Streamable HTTP, no auth, no install), listed on [Glama](https://glama.ai/mcp/servers/JustJuice55/tgden-api)
- **full-text search over posts**, not just channel metadata: `https://tgden.com/en/search?q=QUERY&type=post`

Docs: https://tgden.com/en/api-docs · machine summary: https://tgden.com/llms.txt

Single-line addition.